### PR TITLE
Update package name to "ghjfintegrationapp"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "swampup2024",
+  "name": "ghjfintegrationapp",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "swampup2024",
+      "name": "ghjfintegrationapp",
       "version": "0.0.0",
       "dependencies": {
         "axios": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swampup2024",
+  "name": "ghjfintegrationapp",
   "version": "0.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the project name from `swampup2024` to `ghjfintegrationapp`.